### PR TITLE
Refactored packages into hexagonal architecture (loosely)

### DIFF
--- a/cmd/happendbd/main.go
+++ b/cmd/happendbd/main.go
@@ -12,8 +12,8 @@ import (
 	abciserver "github.com/tendermint/tendermint/abci/server"
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/drgomesp/happendb/pkg/abci"
-	"github.com/drgomesp/happendb/pkg/store"
+	"github.com/drgomesp/happendb/pkg/adapter/abci"
+	"github.com/drgomesp/happendb/pkg/adapter/store"
 )
 
 var socketAddr string

--- a/pkg/adapter/abci/application.go
+++ b/pkg/adapter/abci/application.go
@@ -6,11 +6,11 @@ import (
 	"github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/json"
 
-	"github.com/drgomesp/happendb/pkg"
+	"github.com/drgomesp/happendb/pkg/core"
 )
 
 type TxEvents struct {
-	Events []*happendb.Event `json:"events"`
+	Events []*core.Event `json:"events"`
 }
 
 const (
@@ -24,10 +24,10 @@ const (
 type Application struct {
 	*types.BaseApplication
 
-	store happendb.EventStore
+	store core.EventStore
 }
 
-func NewApplication(store happendb.EventStore) *Application {
+func NewApplication(store core.EventStore) *Application {
 	return &Application{
 		BaseApplication: types.NewBaseApplication(),
 		store:           store,
@@ -47,7 +47,7 @@ func (a *Application) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
 	}
 }
 
-func (a *Application) parseTxEvents(data []byte) ([]*happendb.Event, error) {
+func (a *Application) parseTxEvents(data []byte) ([]*core.Event, error) {
 	var tx TxEvents
 	err := json.Unmarshal(data, &tx)
 

--- a/pkg/adapter/abci/application_test.go
+++ b/pkg/adapter/abci/application_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tendermint/tendermint/abci/example/code"
 	"github.com/tendermint/tendermint/abci/types"
 
-	"github.com/drgomesp/happendb/pkg/store"
+	"github.com/drgomesp/happendb/pkg/adapter/store"
 )
 
 func TestNewApplication(t *testing.T) {

--- a/pkg/adapter/abci/client.go
+++ b/pkg/adapter/abci/client.go
@@ -1,4 +1,4 @@
-package happendb
+package abci
 
 import (
 	"context"
@@ -8,9 +8,11 @@ import (
 	"github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+
+	"github.com/drgomesp/happendb/pkg/core"
 )
 
-var _ EventStore = Client{}
+var _ core.EventStore = &Client{}
 
 type Client struct {
 	abci client.ABCIClient
@@ -28,9 +30,9 @@ func NewClient(remote string) (*Client, error) {
 	}, nil
 }
 
-func (c Client) Save(ctx context.Context, events []*Event, fromVersion int) error {
+func (c *Client) Save(ctx context.Context, events []*core.Event, fromVersion int) error {
 	type EventsTx struct {
-		Events []*Event `json:"events"`
+		Events []*core.Event `json:"events"`
 	}
 
 	data, err := json.Marshal(EventsTx{Events: events})
@@ -52,7 +54,7 @@ func (c Client) Save(ctx context.Context, events []*Event, fromVersion int) erro
 	return nil
 }
 
-func (c Client) Load(ctx context.Context, id string) ([]*Event, error) {
+func (c *Client) Load(ctx context.Context, id string) ([]*core.Event, error) {
 	// Now try to fetch the value for the key
 	res, err := c.abci.ABCIQuery(ctx, id, hexbytes.HexBytes{})
 	if err != nil {
@@ -62,7 +64,7 @@ func (c Client) Load(ctx context.Context, id string) ([]*Event, error) {
 		return nil, err
 	}
 
-	var events []*Event
+	var events []*core.Event
 	spew.Dump(string(res.Response.Value))
 	if err = json.Unmarshal(res.Response.Value, &events); err != nil {
 		return nil, err

--- a/pkg/adapter/abci/client_test.go
+++ b/pkg/adapter/abci/client_test.go
@@ -1,4 +1,4 @@
-package happendb
+package abci
 
 import (
 	"context"
@@ -6,33 +6,35 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/drgomesp/happendb/pkg/core"
 )
 
 type clientMock struct {
 	mock.Mock
 }
 
-func (m *clientMock) Save(ctx context.Context, events []*Event, fromVersion int) error {
+func (m *clientMock) Save(ctx context.Context, events []*core.Event, fromVersion int) error {
 	args := m.Called(ctx, events, fromVersion)
 	return args.Error(0)
 
 }
 
-func (m *clientMock) Load(ctx context.Context, eventType EventType) ([]*Event, error) {
+func (m *clientMock) Load(ctx context.Context, eventType core.EventType) ([]*core.Event, error) {
 	args := m.Called(ctx, eventType)
-	return args.Get(0).([]*Event), args.Error(1)
+	return args.Get(0).([]*core.Event), args.Error(1)
 }
 
 func TestClient_Save(t *testing.T) {
 	tests := []struct {
 		name        string
-		events      []*Event
+		events      []*core.Event
 		fromVersion int
 	}{
 		{
 			name: "save",
-			events: []*Event{
-				NewEvent(
+			events: []*core.Event{
+				core.NewEvent(
 					"repository.RepositoryInitialized",
 					"54e260be-26ce-451a-815d-b2a16e4f3cd0",
 					1,
@@ -61,14 +63,14 @@ func TestClient_Save(t *testing.T) {
 func TestClient_Load(t *testing.T) {
 	tests := []struct {
 		name           string
-		eventType      EventType
-		expectedEvents []*Event
+		eventType      core.EventType
+		expectedEvents []*core.Event
 	}{
 		{
 			name:      "load",
-			eventType: EventType("repository.RepositoryInitialized"),
-			expectedEvents: []*Event{
-				NewEvent(
+			eventType: core.EventType("repository.RepositoryInitialized"),
+			expectedEvents: []*core.Event{
+				core.NewEvent(
 					"repository.RepositoryInitialized",
 					"54e260be-26ce-451a-815d-b2a16e4f3cd0",
 					1,

--- a/pkg/adapter/store/memory.go
+++ b/pkg/adapter/store/memory.go
@@ -3,24 +3,24 @@ package store
 import (
 	"context"
 
-	happendb "github.com/drgomesp/happendb/pkg"
+	"github.com/drgomesp/happendb/pkg/core"
 )
 
-var _ happendb.EventStore = Memory{}
+var _ core.EventStore = Memory{}
 
 type Memory struct {
-	Events map[string][]*happendb.Event
+	Events map[string][]*core.Event
 }
 
 func NewMemory() *Memory {
 	return &Memory{
-		Events: make(map[string][]*happendb.Event, 0),
+		Events: make(map[string][]*core.Event, 0),
 	}
 }
 
-func (m Memory) Save(ctx context.Context, events []*happendb.Event, fromVersion int) error {
+func (m Memory) Save(ctx context.Context, events []*core.Event, fromVersion int) error {
 	if len(events) == 0 {
-		return happendb.ErrStoreMissingEvents
+		return core.ErrStoreMissingEvents
 	}
 
 	head := events[0]
@@ -28,17 +28,17 @@ func (m Memory) Save(ctx context.Context, events []*happendb.Event, fromVersion 
 	empty := len(m.Events[id]) == 0
 
 	if !empty && fromVersion == 0 {
-		return happendb.ErrStoreInvalidVersion
+		return core.ErrStoreInvalidVersion
 	}
 
-	pending := make([]*happendb.Event, len(events))
+	pending := make([]*core.Event, len(events))
 
 	for i := 0; i < len(events); i++ {
 		e := events[i]
 
 		if len(m.Events[id]) > 0 {
 			if fromVersion != 0 && *e.Version != fromVersion+i {
-				return happendb.ErrStoreInvalidVersion
+				return core.ErrStoreInvalidVersion
 			}
 		}
 
@@ -50,7 +50,7 @@ func (m Memory) Save(ctx context.Context, events []*happendb.Event, fromVersion 
 	return nil
 }
 
-func (m Memory) Load(ctx context.Context, id string) ([]*happendb.Event, error) {
+func (m Memory) Load(ctx context.Context, id string) ([]*core.Event, error) {
 	events, ok := m.Events[id]
 	if ok && len(events) > 0 {
 		return events, nil

--- a/pkg/adapter/store/memory_test.go
+++ b/pkg/adapter/store/memory_test.go
@@ -6,33 +6,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	happendb "github.com/drgomesp/happendb/pkg"
-	"github.com/drgomesp/happendb/pkg/store"
+	"github.com/drgomesp/happendb/pkg/adapter/store"
+	"github.com/drgomesp/happendb/pkg/core"
 )
 
 var (
-	e1 = happendb.NewEvent(
+	e1 = core.NewEvent(
 		"repository.RepositoryInitialized",
 		"54e260be-26ce-451a-815d-b2a16e4f3cd0",
 		1,
 		"my-app",
 	)
 
-	e2 = happendb.NewEvent(
+	e2 = core.NewEvent(
 		"repository.RepositoryUpdated",
 		"54e260be-26ce-451a-815d-b2a16e4f3cd0",
 		2,
 		"my-app",
 	)
 
-	e3 = happendb.NewEvent(
+	e3 = core.NewEvent(
 		"repository.RepositoryUpdated",
 		"54e260be-26ce-451a-815d-b2a16e4f3cd0",
 		3,
 		"my-app",
 	)
 
-	e4 = happendb.NewEvent(
+	e4 = core.NewEvent(
 		"repository.RepositoryUpdated",
 		"54e260be-26ce-451a-815d-b2a16e4f3cd0",
 		4,
@@ -43,42 +43,42 @@ var (
 func TestMemoryStore(t *testing.T) {
 	tests := []struct {
 		name                       string
-		events, existing, expected []*happendb.Event
+		events, existing, expected []*core.Event
 		fromVersion                int
 		expectedError              error
 	}{
 		{
 			name:        "test save on empty Events",
-			existing:    []*happendb.Event{},
-			events:      []*happendb.Event{e1, e2},
-			expected:    []*happendb.Event{e1, e2},
+			existing:    []*core.Event{},
+			events:      []*core.Event{e1, e2},
+			expected:    []*core.Event{e1, e2},
 			fromVersion: 0,
 		},
 		{
 			name:        "test save on empty Events from non-zero version",
-			existing:    []*happendb.Event{},
-			events:      []*happendb.Event{e1, e2},
-			expected:    []*happendb.Event{e1, e2},
+			existing:    []*core.Event{},
+			events:      []*core.Event{e1, e2},
+			expected:    []*core.Event{e1, e2},
 			fromVersion: 360,
 		},
 		{
 			name:        "test save on non-empty Events",
-			existing:    []*happendb.Event{e1, e2},
-			events:      []*happendb.Event{e3, e4},
-			expected:    []*happendb.Event{e1, e2, e3, e4},
+			existing:    []*core.Event{e1, e2},
+			events:      []*core.Event{e3, e4},
+			expected:    []*core.Event{e1, e2, e3, e4},
 			fromVersion: 3,
 		}, {
 			name:          "test save on non-empty Events from version zero",
-			existing:      []*happendb.Event{e1, e2},
-			events:        []*happendb.Event{e3},
-			expectedError: happendb.ErrStoreInvalidVersion,
+			existing:      []*core.Event{e1, e2},
+			events:        []*core.Event{e3},
+			expectedError: core.ErrStoreInvalidVersion,
 			fromVersion:   0,
 		},
 		{
 			name:          "test save on non-empty Events from wrong version",
-			existing:      []*happendb.Event{e1, e2},
-			events:        []*happendb.Event{e3},
-			expectedError: happendb.ErrStoreInvalidVersion,
+			existing:      []*core.Event{e1, e2},
+			events:        []*core.Event{e3},
+			expectedError: core.ErrStoreInvalidVersion,
 			fromVersion:   1,
 		},
 	}
@@ -87,7 +87,7 @@ func TestMemoryStore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			memoryStore := store.NewMemory()
-			memoryStore.Events = map[string][]*happendb.Event{
+			memoryStore.Events = map[string][]*core.Event{
 				"repository": tt.existing,
 			}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,4 @@
+package config
+
+type Config struct {
+}

--- a/pkg/core/event.go
+++ b/pkg/core/event.go
@@ -1,4 +1,4 @@
-package happendb
+package core
 
 type EventType string
 

--- a/pkg/core/repository.go
+++ b/pkg/core/repository.go
@@ -1,0 +1,12 @@
+package core
+
+type ReadRepository interface {
+}
+
+type WriteRepository interface {
+}
+
+type ReadWriteRepository interface {
+	ReadRepository
+	WriteRepository
+}

--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -1,4 +1,4 @@
-package happendb
+package core
 
 import (
 	"context"


### PR DESCRIPTION
Fixes #4

This PR introduces a hexagonal-oriented package structure, where the main high-level packages are as follows:

```
├── adapter/
│   ├── abci/ 
│   ├── store/
├── config/
└── core/
```

- `adapter` - Ports and adapters for third-party components used, and also for internally defined components that should be interacting via a client, such as the `abci.Application`.
- `config` - Configuration-specific definitions and utilities
- `core` - The core of the application, which involves storing events and proviving some base abstractions like `Aggregate`, `Repository` and such. 

### Considerations:

I have used both DDD and Hexagonal patterns in many different projects that I've worked on, and they were most of the times different from each other in terms of implementation, however the concepts were all the same. In my opinion, DDD is more useful when you're working with higher-level applications that have more complex business-specific languages. In those cases, DDD will certainly help in defining the layers and separations in a domain-oriented way.

In the case of `happendb`, it could be considered something that might be used by an applicaton but actually sits in a lower-level, infrastrcture layer (which DDD defines). In this situation, it wouldn't make a lot of sense to define repositories and other DDD concepts, unless they provide some real useful abstraction from within the domain of storing events, which is what happendb has as its goal. Nevertheless, I have started defining some base interfaces such as `ReadRepository` and `WriteRepository`, in accordance with DDD, but also allowing for user-defined abstractions that are more business-specific.

Hope that makes sense :)
@arxdsilva 